### PR TITLE
Stove generator option

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -2,10 +2,10 @@
 using MelonLoader;
 using System.Runtime.InteropServices;
 
-// La información general de un ensamblado se controla mediante el siguiente 
+// La información general de un ensamblado se controla mediante el siguiente
 // conjunto de atributos. Cambie estos valores de atributo para modificar la información
 // asociada con un ensamblado.
-[assembly: MelonModInfo(typeof(HouseLights.HouseLights), "House Lights", "2.0", "Xpazeman")]
+[assembly: MelonModInfo(typeof(HouseLights.HouseLights), "House Lights", "2.1", "Xpazeman")]
 [assembly: MelonModGame("Hinterland", "TheLongDark")]
 [assembly: AssemblyTitle("tld-house-lights")]
 [assembly: AssemblyDescription("Small Mod that lets you turn on the lights inside interiors.")]
@@ -16,8 +16,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Si establece ComVisible en false, los tipos de este ensamblado no estarán visibles 
-// para los componentes COM.  Si es necesario obtener acceso a un tipo en este ensamblado desde 
+// Si establece ComVisible en false, los tipos de este ensamblado no estarán visibles
+// para los componentes COM.  Si es necesario obtener acceso a un tipo en este ensamblado desde
 // COM, establezca el atributo ComVisible en true en este tipo.
 [assembly: ComVisible(false)]
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // La información general de un ensamblado se controla mediante el siguiente
 // conjunto de atributos. Cambie estos valores de atributo para modificar la información
 // asociada con un ensamblado.
-[assembly: MelonModInfo(typeof(HouseLights.HouseLights), "House Lights", "2.1", "Xpazeman")]
+[assembly: MelonModInfo(typeof(HouseLights.HouseLights), "House Lights", "2.2", "Xpazeman")]
 [assembly: MelonModGame("Hinterland", "TheLongDark")]
 [assembly: AssemblyTitle("tld-house-lights")]
 [assembly: AssemblyDescription("Small Mod that lets you turn on the lights inside interiors.")]

--- a/src/HouseLights.cs
+++ b/src/HouseLights.cs
@@ -121,7 +121,7 @@ namespace HouseLights
 
         internal static void UpdateElectroLights(AuroraManager mngr)
         {
-            // this should be redundant but in case someone chnage settings in active scene, this should 'reset' ratio
+            // this should be redundant but in case someone change settings in active scene, this should 'reset' ratio
             if (!Settings.options.stoveGenerator)
             {
                 stoveHeatRatio = 1f;

--- a/src/HouseLights.cs
+++ b/src/HouseLights.cs
@@ -28,6 +28,7 @@ namespace HouseLights
         public static List<ElectrolizerLightConfig> electroLightSources = new List<ElectrolizerLightConfig>();
 
         public static List<GameObject> lightSwitches = new List<GameObject>();
+        public static float stoveHeatRatio = 1f;
 
         public override void OnApplicationStart()
         {
@@ -113,7 +114,6 @@ namespace HouseLights
 
             Debug.Log("[house-lights] Light switches found:" + wCount + ".");
         }
-
         internal static void ToggleLightsState()
         {
             lightsOn = !lightsOn;
@@ -121,6 +121,12 @@ namespace HouseLights
 
         internal static void UpdateElectroLights(AuroraManager mngr)
         {
+            // this should be redundant but in case someone chnage settings in active scene, this should 'reset' ratio
+            if (!Settings.options.stoveGenerator)
+            {
+                stoveHeatRatio = 1f;
+            }
+
             for (int e = 0; e < electroSources.Count; e++)
             {
                 if (electroSources[e].electrolizer != null && electroSources[e].electrolizer.m_LocalLights != null)
@@ -159,7 +165,7 @@ namespace HouseLights
                             !electroSources[e].electrolizer.gameObject.name.Contains("ControlBox") &&
                             !electroSources[e].electrolizer.gameObject.name.Contains("Interiorlight"))
                         {
-                            electroSources[e].electrolizer.m_CurIntensity = Settings.options.intensityValue;
+                            electroSources[e].electrolizer.m_CurIntensity = (Settings.options.intensityValue * stoveHeatRatio);
                             electroSources[e].electrolizer.UpdateLight(false);
                             electroSources[e].electrolizer.UpdateFX(false);
                             electroSources[e].electrolizer.UpdateEmissiveObjects(false);
@@ -219,7 +225,7 @@ namespace HouseLights
                             !electroLightSources[e].electrolizer.gameObject.name.Contains("ControlBox") &&
                             !electroLightSources[e].electrolizer.gameObject.name.Contains("Interiorlight"))
                         {
-                            electroLightSources[e].electrolizer.m_CurIntensity = Settings.options.intensityValue;
+                            electroLightSources[e].electrolizer.m_CurIntensity = (Settings.options.intensityValue * stoveHeatRatio);
                             electroLightSources[e].electrolizer.UpdateLight(false);
                             electroLightSources[e].electrolizer.UpdateEmissiveObjects(false);
                             electroLightSources[e].electrolizer.StopAudio();

--- a/src/HouseLights.cs
+++ b/src/HouseLights.cs
@@ -28,13 +28,13 @@ namespace HouseLights
         public static List<ElectrolizerLightConfig> electroLightSources = new List<ElectrolizerLightConfig>();
 
         public static List<GameObject> lightSwitches = new List<GameObject>();
-        public static float stoveHeatRatio = 1f;
+        public static float stoveHeatRatio = 0f;
         public static float stoveTempIncr = 0f;
+        public static bool onlyLow = true;
 
         public override void OnApplicationStart()
         {
             Settings.OnLoad();
-
             Debug.Log("[house-lights] Version " + Assembly.GetExecutingAssembly().GetName().Version);
         }
 

--- a/src/HouseLights.cs
+++ b/src/HouseLights.cs
@@ -29,6 +29,7 @@ namespace HouseLights
 
         public static List<GameObject> lightSwitches = new List<GameObject>();
         public static float stoveHeatRatio = 1f;
+        public static float stoveTempIncr = 0f;
 
         public override void OnApplicationStart()
         {

--- a/src/HouseLightsUtils.cs
+++ b/src/HouseLightsUtils.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using MelonLoader;
 
 namespace HouseLights
 {
@@ -59,7 +60,6 @@ namespace HouseLights
                 for (int i = 0; i < obj.transform.childCount; i++)
                 {
                     GameObject child = obj.transform.GetChild(i).gameObject;
-
                     if (child.name.ToLower().Contains(name))
                     {
                         result.Add(child);

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -149,7 +149,7 @@ namespace HouseLights
         {
             private static void Postfix(Weather __instance, ref bool __result)
             {
-                if (__result && GameManager.GetWeatherComponent().IsIndoorScene() && HouseLights.lightsOn)
+                if (__result && GameManager.GetWeatherComponent().IsIndoorScene() && HouseLights.lightsOn && (HouseLights.stoveHeatRatio >= 0f))
                 {
                     __result = false;
                 }

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -149,7 +149,7 @@ namespace HouseLights
         {
             private static void Postfix(Weather __instance, ref bool __result)
             {
-                if (__result && GameManager.GetWeatherComponent().IsIndoorScene() && HouseLights.lightsOn && HouseLights.stoveHeatRatio >= 0.5f)
+                if (__result && GameManager.GetWeatherComponent().IsIndoorScene() && HouseLights.lightsOn)
                 {
                     __result = false;
                 }
@@ -171,6 +171,7 @@ namespace HouseLights
                         {
                             // get warmest stove in scene
                             float currTempIncr = __instance.GetCurrentTempIncrease();
+                            float throttleDownSec = Settings.options.stoveGeneratorThrottleDown * 60f;
                             if (currTempIncr > HouseLights.stoveTempIncr)
                             {
                                 HouseLights.stoveTempIncr = __instance.GetCurrentTempIncrease();
@@ -180,9 +181,9 @@ namespace HouseLights
                             While we will not fix this (and in a way ember state does keep heat level), we will throttle down electricity output on last 10mins
                             */
                             ratio = Mathf.InverseLerp(Settings.options.stoveGeneratorMinTemp, Settings.options.stoveGeneratorTemp, HouseLights.stoveTempIncr);
-                            if (__instance.GetRemainingLifeTimeSeconds() < 600 && __instance.m_ElapsedOnTODSecondsUnmodified > 600)
+                            if (__instance.GetRemainingLifeTimeSeconds() < throttleDownSec && __instance.m_ElapsedOnTODSecondsUnmodified > throttleDownSec)
                             {
-                                 ratio *= Mathf.InverseLerp(0, 600, __instance.GetRemainingLifeTimeSeconds());
+                                 ratio *= Mathf.InverseLerp(0, throttleDownSec, __instance.GetRemainingLifeTimeSeconds());
                             }
                             HouseLights.stoveHeatRatio = ratio;
                         }

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -36,6 +36,15 @@ namespace HouseLights
         {
             private static void Postfix(MissionServicesManager __instance)
             {
+                // Fire_Update_Prefix will not run if there are no fire sources (eg post office)
+                if (Settings.options.stoveGenerator)
+                {
+                    HouseLights.stoveHeatRatio = 0f;
+                }
+                else
+                {
+                    HouseLights.stoveHeatRatio = 1f;
+                }
                 // if not stove generator, scan extenral and indoors scenes, if using it, scan only internal ones
                 if (!Settings.options.stoveGenerator || (Settings.options.stoveGenerator && GameManager.GetWeatherComponent().IsIndoorScene())) {
                     HouseLights.GetSwitches();

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -161,7 +161,7 @@ namespace HouseLights
                             // get warmest stove in scene
                             float currTempIncr = __instance.GetCurrentTempIncrease();
                             float throttleDownSec = Settings.options.stoveGeneratorThrottleDown * 60f;
-                            if (currTempIncr > HouseLights.stoveTempIncr)
+                            if (currTempIncr >= HouseLights.stoveTempIncr)
                             {
                                 HouseLights.stoveTempIncr = __instance.GetCurrentTempIncrease();
                                 HouseLights.onlyLow = false;

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Harmony;
-using Il2CppSystem.Security.Cryptography.X509Certificates;
-using MelonLoader;
 using UnityEngine;
 
 namespace HouseLights
@@ -38,10 +36,9 @@ namespace HouseLights
         {
             private static void Postfix(MissionServicesManager __instance)
             {
-                // We do not need to scan when outside, right ?
-                if (GameManager.GetWeatherComponent().IsIndoorScene()) {
+                // if not stove generator, scan extenral and indoors scenes, if using it, scan only internal ones
+                if (!Settings.options.stoveGenerator || (Settings.options.stoveGenerator && GameManager.GetWeatherComponent().IsIndoorScene())) {
                     HouseLights.GetSwitches();
-                    //HouseLights.GetStoves();
                 }
             }
         }
@@ -155,14 +152,13 @@ namespace HouseLights
             {
                 if (!Settings.options.stoveGenerator) { return false; }
                 if (GameManager.m_IsPaused) { return false; }
-                // MelonLogger.Log(__instance.GetCurrentTempIncrease());
 
                 float tempIncr = 0f;
                 float currTempIncr = 0f;
 
                 if (__instance.m_HeatSource.IsTurnedOn() && __instance.GetFireState() != FireState.Off) {
-                    GameObject obj = __instance.transform.GetParent().gameObject;
-                    if ((bool)obj.name.ToLower().Contains("woodstove") || obj.name.ToLower().Contains("potbellystove"))
+                    GameObject obj = __instance.transform.GetParent()?.gameObject;
+                    if (obj && (obj.name.ToLower().Contains("woodstove") || obj.name.ToLower().Contains("potbellystove")))
                     {
                         // get warmest stove in scene
                         currTempIncr = __instance.GetCurrentTempIncrease();
@@ -170,8 +166,7 @@ namespace HouseLights
                         {
                             tempIncr = __instance.GetCurrentTempIncrease();
                         }
-                        HouseLights.stoveHeatRatio = Mathf.Clamp(((tempIncr - Settings.options.stoveGeneratorMinTemp) / (Settings.options.stoveGeneratorTemp - Settings.options.stoveGeneratorMinTemp)), 0f, 1f);
-                        //MelonLogger.Log(obj.name + " " + __instance.GetCurrentTempIncrease() + " " + HouseLights.stoveHeatRatio);
+                        HouseLights.stoveHeatRatio = Mathf.InverseLerp(Settings.options.stoveGeneratorMinTemp, Settings.options.stoveGeneratorTemp, tempIncr);
                     }
                 }
                 return false;

--- a/src/Patches.cs
+++ b/src/Patches.cs
@@ -155,6 +155,7 @@ namespace HouseLights
                     {
                         GameObject obj = __instance.transform.GetParent()?.gameObject;
                         float ratio = 0f;
+                        HouseLights.onlyLow = true;
                         if (obj && (obj.name.ToLower().Contains("woodstove") || obj.name.ToLower().Contains("potbellystove")))
                         {
                             // get warmest stove in scene
@@ -163,7 +164,12 @@ namespace HouseLights
                             if (currTempIncr > HouseLights.stoveTempIncr)
                             {
                                 HouseLights.stoveTempIncr = __instance.GetCurrentTempIncrease();
+                                HouseLights.onlyLow = false;
                             }
+                            else if (HouseLights.onlyLow) {
+                                HouseLights.stoveTempIncr = 0;
+                            }
+
                             /*
                             buring out fire does not reduce heat in vanilla game
                             While we will not fix this (and in a way ember state does keep heat level), we will throttle down electricity output on last 10mins

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -28,18 +28,20 @@ namespace HouseLights
         public bool whiteLights = false;
 
         [Name("Stove genrator")]
-        [Description("If setto yes, stoves are working as power generator and needed to be burning (+20C) to get lights. If not, lights work regardless of stove status.")]
+        [Description("If set to yes, stoves are working as power generator and needed to be at certian temperature to get lights. Outside lights will be disabled. If not, lights work regardless of stove status and outside light can be used.")]
         public bool stoveGenerator = false;
+
+        [Name("Generator min temp")]
+        [Description("Minimal stove temperature for electricity to flow. Recommended 15")]
+        [Slider(0f, 80f)]
+        public float stoveGeneratorMinTemp = 15f;
 
         [Name("Generator temp")]
         [Description("Optimal stove temperature for electricity to flow; if temperature is lower than this, it will reduce light intesivity. Recommended 50+")]
-        [Slider(10f, 80f)]
+        [Slider(0f, 80f)]
         public float stoveGeneratorTemp = 50f;
 
-        [Name("Generator min temp")]
-        [Description("Optimal stove temperature for electricity to flow; if temperature is lower than this, it will reduce light intesivity. Recommended 15")]
-        [Slider(0f, 15f)]
-        public float stoveGeneratorMinTemp = 15f;
+
 
         protected override void OnChange(FieldInfo field, object oldValue, object newValue)
         {
@@ -58,6 +60,11 @@ namespace HouseLights
                 SetFieldVisible(nameof(stoveGeneratorTemp), false);
                 SetFieldVisible(nameof(stoveGeneratorMinTemp), false);
             }
+            if (stoveGeneratorMinTemp >= stoveGeneratorTemp)
+            {
+                stoveGeneratorMinTemp = stoveGeneratorTemp - 1;
+                RefreshGUI();
+            }
         }
     }
     internal static class Settings
@@ -67,6 +74,12 @@ namespace HouseLights
         public static void OnLoad()
         {
             options = new HouseLightsSettings();
+            // if someone edited json and tried to be "smart".
+            if (options.stoveGeneratorMinTemp >= options.stoveGeneratorTemp)
+            {
+                options.stoveGeneratorMinTemp = options.stoveGeneratorTemp - 1;
+            }
+            options.RefreshFields();
             options.AddToModSettings("House Lights Settings");
         }
     }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -1,7 +1,5 @@
 ﻿using ModSettings;
-using System.IO;
-using System;
-using System.Text;
+using System.Reflection;
 
 namespace HouseLights
 {
@@ -28,8 +26,40 @@ namespace HouseLights
         [Name("Colorless lights")]
         [Description("If set to yes, lights will cast a more white light. If set to no, they will cast light with the default color.")]
         public bool whiteLights = false;
-    }
 
+        [Name("Stove genrator")]
+        [Description("If setto yes, stoves are working as power generator and needed to be burning (+20C) to get lights. If not, lights work regardless of stove status.")]
+        public bool stoveGenerator = false;
+
+        [Name("Generator temp")]
+        [Description("Optimal stove temperature for electricity to flow; if temperature is lower than this, it will reduce light intesivity. Recommended 50+")]
+        [Slider(10f, 80f)]
+        public float stoveGeneratorTemp = 50f;
+
+        [Name("Generator min temp")]
+        [Description("Optimal stove temperature for electricity to flow; if temperature is lower than this, it will reduce light intesivity. Recommended 15")]
+        [Slider(0f, 15f)]
+        public float stoveGeneratorMinTemp = 15f;
+
+        protected override void OnChange(FieldInfo field, object oldValue, object newValue)
+        {
+            RefreshFields();
+        }
+
+        internal void RefreshFields()
+        {
+            if (stoveGenerator)
+            {
+                SetFieldVisible(nameof(stoveGeneratorTemp), true);
+                SetFieldVisible(nameof(stoveGeneratorMinTemp), true);
+            }
+            else
+            {
+                SetFieldVisible(nameof(stoveGeneratorTemp), false);
+                SetFieldVisible(nameof(stoveGeneratorMinTemp), false);
+            }
+        }
+    }
     internal static class Settings
     {
         public static HouseLightsSettings options;

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -41,7 +41,10 @@ namespace HouseLights
         [Slider(0f, 80f)]
         public float stoveGeneratorTemp = 50f;
 
-
+        [Name("Generator throttle down time ")]
+        [Description("How many minutes before fire will die out, electricity generation will throttle down. Recommended 10 minutes")]
+        [Slider(0.1f, 30f)]
+        public float stoveGeneratorThrottleDown = 10f;
 
         protected override void OnChange(FieldInfo field, object oldValue, object newValue)
         {
@@ -54,11 +57,13 @@ namespace HouseLights
             {
                 SetFieldVisible(nameof(stoveGeneratorTemp), true);
                 SetFieldVisible(nameof(stoveGeneratorMinTemp), true);
+                SetFieldVisible(nameof(stoveGeneratorThrottleDown), true);
             }
             else
             {
                 SetFieldVisible(nameof(stoveGeneratorTemp), false);
                 SetFieldVisible(nameof(stoveGeneratorMinTemp), false);
+                SetFieldVisible(nameof(stoveGeneratorThrottleDown), false);
             }
             if (stoveGeneratorMinTemp >= stoveGeneratorTemp)
             {

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -33,12 +33,12 @@ namespace HouseLights
 
         [Name("Generator min temp")]
         [Description("Minimal stove temperature for electricity to flow. Recommended 15")]
-        [Slider(0f, 80f)]
+        [Slider(10f, 80f)]
         public float stoveGeneratorMinTemp = 15f;
 
         [Name("Generator temp")]
         [Description("Optimal stove temperature for electricity to flow; if temperature is lower than this, it will reduce light intesivity. Recommended 50+")]
-        [Slider(0f, 80f)]
+        [Slider(10f, 80f)]
         public float stoveGeneratorTemp = 50f;
 
         [Name("Generator throttle down time ")]


### PR DESCRIPTION
Adds option to enable lights only when stove / pot belly is fueled and at certain temperature.

This will add trade-off to run lights, and it's idea is that stoves are also small power generators.